### PR TITLE
Bump num-traits to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["ecc", "fec", "binary", "field", "matrix"]
 
 [dependencies]
 
-num-traits = "0.1.41"
+num-traits = "0.2"


### PR DESCRIPTION
`num-traits`' dependency tree has become a bit of a mess, as `0.2` now depends on `0.1`. Use `0.2` explicitly, which doesn't require any code changes.

Tests are green.